### PR TITLE
Tweaks to Terraform + create script

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "terraform/**"
+      - "sql/**"
 
 jobs:
   test-entity-counter-recalculator:

--- a/sql/create_users.sql
+++ b/sql/create_users.sql
@@ -3,7 +3,7 @@ CREATE USER customerstoragerecalc_user WITH ENCRYPTED PASSWORD 'xxx';
 GRANT SELECT, INSERT, UPDATE ON "CustomerStorage" TO customerstoragerecalc_user;
 GRANT SELECT ON "ImageStorage" TO customerstoragerecalc_user;
 
--- Create user for CustomerStorage recalculator script
+-- Create user for EntityCounter recalculator script
 CREATE USER entitycounterrecalc_user WITH ENCRYPTED PASSWORD 'xxx';
 GRANT SELECT, INSERT, UPDATE ON "EntityCounters" TO entitycounterrecalc_user;
 GRANT SELECT ON "Images" TO entitycounterrecalc_user;

--- a/sql/create_users.sql
+++ b/sql/create_users.sql
@@ -1,0 +1,9 @@
+-- Create user for CustomerStorage recalculator script
+CREATE USER customerstoragerecalc_user WITH ENCRYPTED PASSWORD 'xxx';
+GRANT SELECT, INSERT, UPDATE ON "CustomerStorage" TO customerstoragerecalc_user;
+GRANT SELECT ON "ImageStorage" TO customerstoragerecalc_user;
+
+-- Create user for CustomerStorage recalculator script
+CREATE USER entitycounterrecalc_user WITH ENCRYPTED PASSWORD 'xxx';
+GRANT SELECT, INSERT, UPDATE ON "EntityCounters" TO entitycounterrecalc_user;
+GRANT SELECT ON "Images" TO entitycounterrecalc_user;

--- a/src/customer_storage_recalculator.py
+++ b/src/customer_storage_recalculator.py
@@ -98,11 +98,19 @@ def __run_sql(conn):
                Count("Id") AS numberOfImagesInImage,
                SUM("ThumbnailSize") as totalSizeOfThumbnailsInImage
         FROM "ImageStorage" GROUP BY "Customer", "Space" ORDER BY "Customer", "Space"), ins AS (
-        INSERT INTO "CustomerStorage" AS y
+        INSERT INTO "CustomerStorage"
+               ( "Customer", "StoragePolicy", "NumberOfStoredImages", "TotalSizeOfStoredImages", "TotalSizeOfThumbnails", "LastCalculated", "Space" )
                SELECT cte."Customer", 'default', cte.numberOfImagesInImage, cte.TotalSizeInImage, cte.totalSizeOfThumbnailsInImage, current_timestamp, cte."Space"
                 FROM cte
                ON CONFLICT ("Customer", "Space")
-               DO UPDATE SET ("Customer", "StoragePolicy", "NumberOfStoredImages", "TotalSizeOfStoredImages", "TotalSizeOfThumbnails", "LastCalculated", "Space") = ROW(excluded.*)
+               DO UPDATE SET
+                   "Customer" = excluded."Customer",
+                   "StoragePolicy" = excluded."StoragePolicy",
+                   "NumberOfStoredImages" = excluded."NumberOfStoredImages",
+                   "TotalSizeOfStoredImages" = excluded."TotalSizeOfStoredImages",
+                    "TotalSizeOfThumbnails" = excluded."TotalSizeOfThumbnails",
+                   "LastCalculated" = excluded."LastCalculated",
+                   "Space" = excluded."Space"
                RETURNING *)
         SELECT y."Customer",
                cte."Customer" AS customerInImage,

--- a/src/entity_counter_recalculator.py
+++ b/src/entity_counter_recalculator.py
@@ -33,8 +33,6 @@ def begin_cleanup():
 
 
 def set_cloudwatch_metrics(records, cloudwatch, connection_info):
-    customer_delta = 0
-    customer_deletes_needed = 0
     metric_data = []
     dimensions = [{
                     'Name': "TABLE_NAME",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "lambda_docker_function_permissions" {
 }
 
 resource "aws_cloudwatch_event_rule" "lambda_docker_cloudwatch_cron_rule" {
-  name                = "${var.function_name}-cloudwatch-cron-rule"
+  name                = var.function_name
   description         = "${var.function_name} CRON rule for scheduling runs"
   schedule_expression = "cron(${var.cron_schedule})"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,19 +1,19 @@
-resource  "aws_cloudwatch_log_group" "lambda_docker_log_group" {
-  name = "/aws/lambda/${var.function_name}"
+resource "aws_cloudwatch_log_group" "lambda_docker_log_group" {
+  name              = "/aws/lambda/${var.function_name}"
   retention_in_days = var.retention_in_days
 }
 
 resource "aws_lambda_function" "lambda_docker_function" {
   function_name = var.function_name
-  package_type = "Image"
+  package_type  = "Image"
   role          = aws_iam_role.lambda_docker_function_exec_role.arn
   image_uri     = var.image_uri
   timeout       = var.lambda_timeout
 
   vpc_config {
-      subnet_ids         = var.subnet_ids
-      security_group_ids = var.security_group_ids
-    }
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
+  }
 
   environment {
     variables = var.environment
@@ -39,8 +39,8 @@ resource "aws_iam_role" "lambda_docker_function_exec_role" {
 }
 
 resource "aws_iam_role_policy" "lambda_docker_function_logging" {
-  name               = "${var.function_name}-exec-role"
-  role       = aws_iam_role.lambda_docker_function_exec_role.name
+  name   = "${var.function_name}-exec-role"
+  role   = aws_iam_role.lambda_docker_function_exec_role.name
   policy = data.aws_iam_policy_document.lambda_docker_function_permissions.json
 }
 
@@ -64,20 +64,20 @@ data "aws_iam_policy_document" "lambda_docker_function_permissions" {
 }
 
 resource "aws_cloudwatch_event_rule" "lambda_docker_cloudwatch_cron_rule" {
-  name = "${var.function_name}-cloudwatch-cron-rule"
-  description = "${var.function_name} CRON rule for scheduling runs"
+  name                = "${var.function_name}-cloudwatch-cron-rule"
+  description         = "${var.function_name} CRON rule for scheduling runs"
   schedule_expression = "cron(${var.cron_schedule})"
 }
 
 resource "aws_lambda_permission" "lambda_docker_cron_permission" {
-  statement_id = "${var.function_name}-allow-cloudwatch-execution"
-  action = "lambda:InvokeFunction"
+  statement_id  = "${var.function_name}-allow-cloudwatch-execution"
+  action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.lambda_docker_function.arn
-  principal = "events.amazonaws.com"
-  source_arn = aws_cloudwatch_event_rule.lambda_docker_cloudwatch_cron_rule.arn
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.lambda_docker_cloudwatch_cron_rule.arn
 }
 
 resource "aws_cloudwatch_event_target" "lambda_docker_cloudwatch_target" {
   rule = aws_cloudwatch_event_rule.lambda_docker_cloudwatch_cron_rule.name
-  arn = aws_lambda_function.lambda_docker_function.arn
+  arn  = aws_lambda_function.lambda_docker_function.arn
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,8 @@ variable "security_group_ids" {
 
 variable "environment" {
   type        = map(string)
-  description = "Environment variables to set on lambda"
+  description = "Environment variables to set on lambda, AWS_CONNECTION_STRING_LOCATION automatically set"
+  default     = {}
 }
 
 variable "function_name" {
@@ -36,4 +37,9 @@ variable "cron_schedule" {
 variable "retention_in_days" {
   default     = 14
   description = "Number of days to retain CloudWatch logs for"
+}
+
+variable "ssm_connection_string" {
+  type        = string
+  description = "SSM key storing connection string"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,30 +1,39 @@
-variable "region" {
-}
-
 variable "image_uri" {
+  type        = string
+  description = "ECR image URI containing the function's deployment package."
 }
 
 variable "lambda_timeout" {
+  default     = 3
+  description = "Amount of time your Lambda Function has to run in seconds. Defaults to 3"
 }
 
 variable "subnet_ids" {
+  type        = list(string)
+  description = "List of subnet IDs associated with the Lambda function."
 }
 
 variable "security_group_ids" {
+  type        = list(string)
+  description = "List of security group IDs associated with the Lambda function"
 }
 
 variable "environment" {
-  type = map(string)
+  type        = map(string)
+  description = "Environment variables to set on lambda"
 }
 
 variable "function_name" {
-
+  type        = string
+  description = "Unique name for Lambda Function"
 }
 
 variable "cron_schedule" {
-
+  type        = string
+  description = "The CRON scheduling expression only (without wrapping 'cron()')"
 }
 
 variable "retention_in_days" {
-  default = 14
+  default     = 14
+  description = "Number of days to retain CloudWatch logs for"
 }


### PR DESCRIPTION
Made the following changes to Terraform:
* Removed "-cloudwatch-cron-rule" postfix from CW event name, there's a 64 char limit and this adds 22 chars.
* Add description + types to `variables.tf`
* Ran `terraform fmt` and remove unused `region` variable
* Reduce the ssm permissions for the lambda by restricting to a specific SSM value.

In addition to the above this PR:
* Adds a sample sql script for creating different pg users for running scripts
* Removes 2 unused vars from entity-counter py script
* Explicitly sets the `"CustomerStorage"` column names as the ordering is inconsistent between different DLCS setups (due to some created with legacy sql script and EF).