### PR TITLE
Updating build to push to public ECR

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -14,6 +14,9 @@ inputs:
   github-token:
     description: "The GitHub token used when interacting with GCHR."
     required: true
+  ecr-role:
+    description: "The GitHub token used when interacting with GCHR."
+    required: true
 
 runs:
   using: "composite"
@@ -38,7 +41,7 @@ runs:
     - id: configure-aws-creds
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        role-to-assume: ${{ secrets.ECR_ROLE }}
+        role-to-assume: ${{ inputs.ecr-role }}
         aws-region: us-east-1
 
     - id: login-ecr

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -37,6 +37,8 @@ runs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
+          # change to refs/tags/
+          type=raw,value=production,enable=${{ startsWith(github.ref, 'refs/pull') }}
 
     - id: configure-aws-creds
       uses: aws-actions/configure-aws-credentials@v4
@@ -50,6 +52,12 @@ runs:
         registry-type: public
         mask-password: 'true'
 
+    - id: add-production-tag
+      if: startsWith(github.ref, 'refs/tags/')
+      shell: bash
+      run: |
+        
+
     - id: docker-build-push
       uses: docker/build-push-action@v4
       with:
@@ -60,14 +68,14 @@ runs:
         labels: ${{ steps.docker-meta.outputs.labels }}
         push: ${{ github.actor != 'dependabot[bot]' }}
 
-    - id: tag-production
-#      if: startsWith(github.ref, 'refs/tags/')
-      shell: bash
-      env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        REGISTRY_ALIAS: j8m2g9d5
-      run: |
-        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:${{ github.sha }} ${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:production
+#    - id: tag-production
+##      if: startsWith(github.ref, 'refs/tags/')
+#      shell: bash
+#      env:
+#        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#        REGISTRY_ALIAS: j8m2g9d5
+#      run: |
+#        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:${{ github.sha }} ${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:production
 
 #    - id: build-tag-push
 #      shell: bash

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -67,10 +67,6 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REGISTRY_ALIAS: j8m2g9d5
       run: |
-#        cd ${{ inputs.context }}
-#        docker build -t ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.s }} ${{ inputs.dockerfile }}
-#        docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
-#        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
         docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
 
 #    - id: build-tag-push

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -3,19 +3,16 @@ description: Composite GitHub Action to build and push Docker images to the DLCS
 
 inputs:
   image-name:
-    description: "Name of the image to push to the GHCR repository."
+    description: "Name of the image to push to the ECR repository."
     required: true
   dockerfile:
-    description: "The EntityCounterDockerfile to build and push."
+    description: "The DockerFile to build and push."
     required: true
   context:
-    description: "The context to use when building the EntityCounterDockerfile."
-    required: true
-  github-token:
-    description: "The GitHub token used when interacting with GCHR."
+    description: "The context to use when building the Dockerfile."
     required: true
   ecr-role:
-    description: "The GitHub token used when interacting with GCHR."
+    description: "The name of the role to log into ECR with"
     required: true
 
 runs:
@@ -37,8 +34,6 @@ runs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          # change to refs/tags/
-          type=raw,value=production,enable=${{ startsWith(github.ref, 'refs/pull') }}
 
     - id: configure-aws-creds
       uses: aws-actions/configure-aws-credentials@v4
@@ -52,12 +47,6 @@ runs:
         registry-type: public
         mask-password: 'true'
 
-    - id: add-production-tag
-      if: startsWith(github.ref, 'refs/tags/')
-      shell: bash
-      run: |
-        
-
     - id: docker-build-push
       uses: docker/build-push-action@v4
       with:
@@ -67,40 +56,3 @@ runs:
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
         push: ${{ github.actor != 'dependabot[bot]' }}
-
-#    - id: tag-production
-##      if: startsWith(github.ref, 'refs/tags/')
-#      shell: bash
-#      env:
-#        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#        REGISTRY_ALIAS: j8m2g9d5
-#      run: |
-#        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:${{ github.sha }} ${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:production
-
-#    - id: build-tag-push
-#      shell: bash
-#      env:
-#        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-#        ECR_REPOSITORY: j8m2g9d5
-#        IMAGE_TAG: latest
-#      run: |
-#        cd ${{ inputs.context }}
-#        docker build -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }} ${{ inputs.dockerfile }}
-#        docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
-
-
-#    - id: docker-login
-#      uses: docker/login-action@v2
-#      with:
-#        registry: ghcr.io
-#        username: ${{ github.actor }}
-#        password: ${{ inputs.github-token }}
-#    - id: docker-build-push
-#      uses: docker/build-push-action@v4
-#      with:
-#        context: ${{ inputs.context }}
-#        file: ${{ inputs.dockerfile }}
-#        builder: ${{ steps.docker-setup-buildx.outputs.name }}
-#        tags: ${{ steps.docker-meta.outputs.tags }}
-#        labels: ${{ steps.docker-meta.outputs.labels }}
-#        push: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -22,10 +22,11 @@ runs:
       uses: actions/checkout@v3
     - id: docker-setup-buildx
       uses: docker/setup-buildx-action@v2
+
     - id: docker-meta
       uses: docker/metadata-action@v4
       with:
-        images: ghcr.io/dlcs/${{ inputs.image-name }}
+        images: public.ecr.aws/j8m2g9d5/${{ inputs.image-name }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr
@@ -33,12 +34,19 @@ runs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-    - id: docker-login
-      uses: docker/login-action@v2
+
+    - id: configure-aws-creds
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ inputs.github-token }}
+        role-to-assume: ${{ secrets.ECR_ROLE }}
+        aws-region: us-east-1
+
+    - id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v2
+      with:
+        registry-type: public
+        mask-password: 'true'
+
     - id: docker-build-push
       uses: docker/build-push-action@v4
       with:
@@ -48,3 +56,40 @@ runs:
         tags: ${{ steps.docker-meta.outputs.tags }}
         labels: ${{ steps.docker-meta.outputs.labels }}
         push: ${{ github.actor != 'dependabot[bot]' }}
+
+    - id: tag-production
+#      if: startsWith(github.ref, 'refs/tags/')
+      shell: bash
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        REGISTRY_ALIAS: j8m2g9d5
+      run: |
+        docker tag ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
+
+#    - id: build-tag-push
+#      shell: bash
+#      env:
+#        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+#        ECR_REPOSITORY: j8m2g9d5
+#        IMAGE_TAG: latest
+#      run: |
+#        cd ${{ inputs.context }}
+#        docker build -t ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }} ${{ inputs.dockerfile }}
+#        docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+
+
+#    - id: docker-login
+#      uses: docker/login-action@v2
+#      with:
+#        registry: ghcr.io
+#        username: ${{ github.actor }}
+#        password: ${{ inputs.github-token }}
+#    - id: docker-build-push
+#      uses: docker/build-push-action@v4
+#      with:
+#        context: ${{ inputs.context }}
+#        file: ${{ inputs.dockerfile }}
+#        builder: ${{ steps.docker-setup-buildx.outputs.name }}
+#        tags: ${{ steps.docker-meta.outputs.tags }}
+#        labels: ${{ steps.docker-meta.outputs.labels }}
+#        push: ${{ github.actor != 'dependabot[bot]' }}

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -67,7 +67,7 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REGISTRY_ALIAS: j8m2g9d5
       run: |
-        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
+        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:${{ github.sha }} ${{ env.REGISTRY_ALIAS }}/${{ inputs.image-name }}:production
 
 #    - id: build-tag-push
 #      shell: bash

--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -67,7 +67,11 @@ runs:
         ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         REGISTRY_ALIAS: j8m2g9d5
       run: |
-        docker tag ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
+#        cd ${{ inputs.context }}
+#        docker build -t ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.s }} ${{ inputs.dockerfile }}
+#        docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+#        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
+        docker tag ${{ env.ECR_REGISTRY }}/${{ env.REGISTRY_ALIAS }}:${{ github.sha }} ${{ env.REGISTRY }}/${{ env.REGISTRY_ALIAS }}:production
 
 #    - id: build-tag-push
 #      shell: bash

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -58,7 +58,6 @@ jobs:
           image-name: "dlcservices-entity-counter-recalculator"
           dockerfile: "src/EntityCounterDockerfile"
           context: "./src"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           ecr-role: ${{ secrets.ECR_ROLE }}
 
   build-push-dlcs-customer-storage-recalculator:
@@ -71,5 +70,4 @@ jobs:
           image-name: "dlcservices-customer-storage-recalculator"
           dockerfile: "src/CustomerStorageDockerfile"
           context: "./src"
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           ecr-role: ${{ secrets.ECR_ROLE }}

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -59,6 +59,7 @@ jobs:
           dockerfile: "src/EntityCounterDockerfile"
           context: "./src"
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ecr-role: ${{ secrets.ECR_ROLE }}
 
   build-push-dlcs-customer-storage-recalculator:
     runs-on: ubuntu-latest
@@ -71,3 +72,4 @@ jobs:
           dockerfile: "src/CustomerStorageDockerfile"
           context: "./src"
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          ecr-role: ${{ secrets.ECR_ROLE }}

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -13,6 +13,10 @@ on:
       - "terraform/**"
       - "sql/**"
 
+permissions:
+  id-token: write  # required for OIDC / AWS
+  contents: read   # This is required for actions/checkout
+
 jobs:
   test-entity-counter-recalculator:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/docker-build-and-push
         with:
-          image-name: "entity-counter-recalculator"
+          image-name: "dlcservices-entity-counter-recalculator"
           dockerfile: "src/EntityCounterDockerfile"
           context: "./src"
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/docker-build-and-push
         with:
-          image-name: "customer-storage-recalculator"
+          image-name: "dlcservices-customer-storage-recalculator"
           dockerfile: "src/CustomerStorageDockerfile"
           context: "./src"
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the github action to push directly into a public ECR repository, as opposed to a github repository.