### PR TITLE
Slight tweaks to logging

### DIFF
--- a/src/customer_storage_recalculator.py
+++ b/src/customer_storage_recalculator.py
@@ -11,17 +11,19 @@ from app.aws_factory import get_aws_client
 from app.database import connect_to_postgres, get_connection_config
 
 
-def begin_cleanup():
+def run_cleanup():
+    logger.info("Running customer storage recalculator")
     connection_info = get_connection_config(CONNECTION_STRING)
     conn = connect_to_postgres(connection_info=connection_info, connection_timeout=CONNECTION_TIMEOUT)
     records = __run_sql(conn)
 
     if ENABLE_CLOUDWATCH_INTEGRATION:
-        logger.info("setting cloudwatch metrics")
+        logger.info("CloudWatch metrics enabled")
         cloudwatch = get_aws_client(resource_type="cloudwatch", region=REGION)
         set_cloudwatch_metrics(records, cloudwatch, connection_info)
 
     conn.close()
+    logger.info("Customer storage recalculator complete")
 
     return records
 
@@ -46,7 +48,7 @@ def set_cloudwatch_metrics(records, cloudwatch, connection_info):
     space_total_thumbnail_size_delta = 0
 
     for key in records["spaceChanges"]:
-        logger.info(f"space delta found - {key}")
+        logger.info(f"Space delta - {key}")
         space_total_image_size_delta += abs(key["totalsizedelta"])
         space_total_image_number_delta += abs(key["numberofimagesdelta"])
         space_total_thumbnail_size_delta += abs(key["totalsizeofthumbnailsdelta"])
@@ -73,12 +75,12 @@ def set_cloudwatch_metrics(records, cloudwatch, connection_info):
     ])
 
     try:
-        logger.debug(f"updating cloudwatch metrics - {metric_data}")
+        logger.debug(f"Publishing CloudWatch metrics - {metric_data}")
         cloudwatch.put_metric_data(MetricData=metric_data,
                                    Namespace='Protagonist Recalculator')
         return metric_data
     except Exception as e:
-        logger.error(f"Error posting to cloudwatch: {e}")
+        logger.exception(f"Error publishing to CloudWatch")
         raise e
 
 
@@ -153,7 +155,7 @@ def __run_sql(conn):
     logger.info(records)
 
     if DRY_RUN:
-        logger.info(f"DRY RUN ENABLED.  Changes have not been committed to the database")
+        logger.info(f"DRY RUN ENABLED. Changes have not been committed to the database")
     else:
         conn.commit()
 
@@ -163,4 +165,4 @@ def __run_sql(conn):
 
 
 if __name__ == "__main__":
-    begin_cleanup()
+    run_cleanup()

--- a/src/entity_counter_recalculator.py
+++ b/src/entity_counter_recalculator.py
@@ -11,17 +11,19 @@ from app.aws_factory import get_aws_client
 from app.database import connect_to_postgres, get_connection_config
 
 
-def begin_cleanup():
+def run_cleanup():
+    logger.info("Running entity counter recalculator")
     connection_info = get_connection_config(CONNECTION_STRING)
     conn = connect_to_postgres(connection_info=connection_info,connection_timeout=CONNECTION_TIMEOUT)
     records = __run_sql(conn)
 
     if ENABLE_CLOUDWATCH_INTEGRATION:
-        logger.info("setting cloudwatch metrics")
+        logger.info("CloudWatch metrics enabled")
         cloudwatch = get_aws_client(resource_type="cloudwatch", region=REGION)
         set_cloudwatch_metrics(records, cloudwatch, connection_info)
 
     conn.close()
+    logger.info("Entity counter recalculator complete")
 
     return records
 
@@ -45,7 +47,7 @@ def set_cloudwatch_metrics(records, cloudwatch, connection_info):
     space_deletes_needed = 0
 
     for key in records["spaceImages"]:
-        logger.info(f"space images delta found - {key}")
+        logger.info(f"Space images delta - {key}")
         if key["delta"] is not None:
             space_delta += abs(key["delta"])
         else:
@@ -67,12 +69,12 @@ def set_cloudwatch_metrics(records, cloudwatch, connection_info):
     ])
 
     try:
-        logger.debug(f"updating cloudwatch metrics - {metric_data}")
+        logger.debug(f"Publishing CloudWatch metrics - {metric_data}")
         cloudwatch.put_metric_data(MetricData=metric_data,
                                    Namespace='Protagonist Recalculator')
         return metric_data
     except Exception as e:
-        logger.error(f"Error posting to cloudwatch: {e}")
+        logger.exception(f"Error publishing to CloudWatch")
         raise e
 
 
@@ -123,7 +125,7 @@ def __run_sql(conn):
     logger.info(records)
 
     if DRY_RUN:
-        logger.info(f"DRY RUN ENABLED.  Changes have not been committed to the database")
+        logger.info(f"DRY RUN ENABLED. Changes have not been committed to the database")
     else:
         conn.commit()
 
@@ -133,4 +135,4 @@ def __run_sql(conn):
 
 
 if __name__ == "__main__":
-    begin_cleanup()
+    run_cleanup()

--- a/src/test_customer_storage_recalculator.py
+++ b/src/test_customer_storage_recalculator.py
@@ -25,7 +25,7 @@ class TestFunction(unittest.TestCase):
         mock_cur = mock_con.cursor.return_value
         mock_cur.fetchall.return_value = expected
 
-        result = customer_storage_recalculator.begin_cleanup()
+        result = customer_storage_recalculator.run_cleanup()
 
         self.assertEqual(result, {'spaceChanges': [['fake', 'row', 1], ['fake', 'row', 2]]})
 
@@ -49,7 +49,7 @@ class TestFunction(unittest.TestCase):
         factory.get_aws_client = boto3.client("cloudwatch", region_name='eu-west-2')
 
         try:
-            customer_storage_recalculator.begin_cleanup()
+            customer_storage_recalculator.run_cleanup()
         except Exception:
             self.fail("myFunc() raised ExceptionType unexpectedly!")
 
@@ -68,7 +68,7 @@ class TestFunction(unittest.TestCase):
         mock_cur.fetchall.return_value = expected
 
         with self.assertRaises(ParamValidationError):
-            customer_storage_recalculator.begin_cleanup()
+            customer_storage_recalculator.run_cleanup()
 
     @mock.patch("customer_storage_recalculator.CLOUDWATCH_SPACE_IMAGE_SIZE_DIFFERENCE_METRIC_NAME", "test4")
     @mock.patch("customer_storage_recalculator.CLOUDWATCH_SPACE_IMAGE_NUMBER_DIFFERENCE_METRIC_NAME", "test5")

--- a/src/test_entity_counter_recalculator.py
+++ b/src/test_entity_counter_recalculator.py
@@ -25,7 +25,7 @@ class TestFunction(unittest.TestCase):
         mock_cur = mock_con.cursor.return_value
         mock_cur.fetchall.return_value = expected
 
-        result = entity_counter_recalculator.begin_cleanup()
+        result = entity_counter_recalculator.run_cleanup()
 
         self.assertEqual(result, {'spaceImages': [['fake', 'row', 1], ['fake', 'row', 2]]})
 
@@ -48,7 +48,7 @@ class TestFunction(unittest.TestCase):
         factory.get_aws_client = boto3.client("cloudwatch", region_name='eu-west-2')
 
         try:
-            entity_counter_recalculator.begin_cleanup()
+            entity_counter_recalculator.run_cleanup()
         except Exception:
             self.fail("myFunc() raised ExceptionType unexpectedly!")
 
@@ -66,7 +66,7 @@ class TestFunction(unittest.TestCase):
         mock_cur.fetchall.return_value = expected
 
         with self.assertRaises(ParamValidationError):
-            entity_counter_recalculator.begin_cleanup()
+            entity_counter_recalculator.run_cleanup()
 
     @mock.patch("entity_counter_recalculator.CLOUDWATCH_SPACE_DIFFERENCE_METRIC_NAME", "test2")
     @mock.patch("entity_counter_recalculator.CLOUDWATCH_SPACE_DELETE_METRIC_NAME", "test3")


### PR DESCRIPTION
Main intention was to remove "found" from logged messages as this was confusing if the delta was null. Also added confirmation of start/stop to make logs more self explanatory.

Last tweak was `begin_cleanup()` => `run_cleanup()` as it felt it captured what was happening better (ie it's not a 'begin' then walk away, it's running the whole thing).