### PR TITLE
Fix customer storage records with no imageStorage records not having last calculated updated

### DIFF
--- a/src/customer_storage_recalculator.py
+++ b/src/customer_storage_recalculator.py
@@ -223,7 +223,7 @@ def __run_sql(conn):
     # The old values are captured via the to_zero CTE (which reads the pre-update snapshot) so
     # they can be reported as deltas alongside the changes from step 1.
     cur.execute("""
-        -- Identify non-null spaces that have non-zero totals but no remaining ImageStorage records.
+        -- Identify non-null spaces with no remaining ImageStorage records.
         WITH to_zero AS (
             SELECT "Customer", "Space",
                    "NumberOfStoredImages", "TotalSizeOfStoredImages", "TotalSizeOfThumbnails",
@@ -235,13 +235,11 @@ def __run_sql(conn):
                 WHERE "ImageStorage"."Customer" = "CustomerStorage"."Customer"
                   AND "ImageStorage"."Space" = "CustomerStorage"."Space"
               )
-              AND (   "NumberOfStoredImages"    != 0
-                   OR "TotalSizeOfStoredImages" != 0
-                   OR "TotalSizeOfThumbnails"   != 0
-                   OR "NumberOfStoredAdjuncts"  != 0
-                   OR "TotalSizeOfStoredAdjuncts" != 0)
         ),
-        -- Zero out the identified rows.
+        -- Zero out the identified rows and stamp LastCalculated.
+        -- Covers both non-zero rows (actual changes) and already-zero rows (e.g. space 0 with
+        -- no images/adjuncts) that are skipped by the step 1 upsert but still need LastCalculated
+        -- updated. The final SELECT filters to only rows with non-zero deltas for reporting.
         zeroed AS (
             UPDATE "CustomerStorage"
             SET "NumberOfStoredImages"      = 0,
@@ -253,28 +251,9 @@ def __run_sql(conn):
             FROM to_zero
             WHERE "CustomerStorage"."Customer" = to_zero."Customer"
               AND "CustomerStorage"."Space"    = to_zero."Space"
-        ),
-        -- Update LastCalculated for spaces that are already zero but have no ImageStorage records
-        -- (e.g. space 0 with no images/adjuncts). These are skipped by the upsert in step 1
-        -- (no ImageStorage rows) and by the zeroed CTE above (already-zero values pass no rows
-        -- through to_zero). This CTE is mutually exclusive with zeroed: to_zero requires at
-        -- least one non-zero value, whereas this targets rows where all values are already 0.
-        last_calc_update AS (
-            UPDATE "CustomerStorage"
-            SET "LastCalculated" = current_timestamp
-            WHERE "Space" IS NOT NULL
-              AND NOT EXISTS (
-                SELECT 1 FROM "ImageStorage"
-                WHERE "ImageStorage"."Customer" = "CustomerStorage"."Customer"
-                  AND "ImageStorage"."Space"    = "CustomerStorage"."Space"
-              )
-              AND "NumberOfStoredImages"      = 0
-              AND "TotalSizeOfStoredImages"   = 0
-              AND "TotalSizeOfThumbnails"     = 0
-              AND "NumberOfStoredAdjuncts"    = 0
-              AND "TotalSizeOfStoredAdjuncts" = 0
         )
         -- Return the old (pre-zero) values as deltas so they feed into CloudWatch metrics.
+        -- Rows already at zero are excluded — their delta is 0 so nothing meaningful to report.
         SELECT "Customer",
                "Space",
                "TotalSizeOfStoredImages",
@@ -292,7 +271,12 @@ def __run_sql(conn):
                "NumberOfStoredAdjuncts",
                0 AS "NumberOfAdjunctsInAdjunctsTable",
                "NumberOfStoredAdjuncts"    AS "NumberOfAdjunctsDelta"
-        FROM to_zero;
+        FROM to_zero
+        WHERE "NumberOfStoredImages"    != 0
+           OR "TotalSizeOfStoredImages" != 0
+           OR "TotalSizeOfThumbnails"   != 0
+           OR "NumberOfStoredAdjuncts"  != 0
+           OR "TotalSizeOfStoredAdjuncts" != 0;
         """)
 
     zeroed_space_changes = cur.fetchall()

--- a/src/customer_storage_recalculator.py
+++ b/src/customer_storage_recalculator.py
@@ -253,6 +253,26 @@ def __run_sql(conn):
             FROM to_zero
             WHERE "CustomerStorage"."Customer" = to_zero."Customer"
               AND "CustomerStorage"."Space"    = to_zero."Space"
+        ),
+        -- Update LastCalculated for spaces that are already zero but have no ImageStorage records
+        -- (e.g. space 0 with no images/adjuncts). These are skipped by the upsert in step 1
+        -- (no ImageStorage rows) and by the zeroed CTE above (already-zero values pass no rows
+        -- through to_zero). This CTE is mutually exclusive with zeroed: to_zero requires at
+        -- least one non-zero value, whereas this targets rows where all values are already 0.
+        last_calc_update AS (
+            UPDATE "CustomerStorage"
+            SET "LastCalculated" = current_timestamp
+            WHERE "Space" IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM "ImageStorage"
+                WHERE "ImageStorage"."Customer" = "CustomerStorage"."Customer"
+                  AND "ImageStorage"."Space"    = "CustomerStorage"."Space"
+              )
+              AND "NumberOfStoredImages"      = 0
+              AND "TotalSizeOfStoredImages"   = 0
+              AND "TotalSizeOfThumbnails"     = 0
+              AND "NumberOfStoredAdjuncts"    = 0
+              AND "TotalSizeOfStoredAdjuncts" = 0
         )
         -- Return the old (pre-zero) values as deltas so they feed into CloudWatch metrics.
         SELECT "Customer",

--- a/src/test_customer_storage_recalculator.py
+++ b/src/test_customer_storage_recalculator.py
@@ -70,6 +70,23 @@ class TestFunction(unittest.TestCase):
     @mock.patch("psycopg2.connect")
     @mock.patch("customer_storage_recalculator.CONNECTION_STRING",
                 "postgresql://user:pass@host:1234/postgres")  # pragma: allowlist secret
+    def test_step2_sql_updates_last_calculated_for_already_zero_spaces(self, mock_connect):
+        # Spaces that already have all-zero values and no ImageStorage records (e.g. space 0
+        # with no images/adjuncts) must still have LastCalculated touched. Verify the step 2
+        # SQL contains the last_calc_update CTE that handles this case.
+        mock_con = mock_connect.return_value
+        mock_cur = mock_con.cursor.return_value
+        mock_cur.fetchall.side_effect = [[], []]
+
+        customer_storage_recalculator.run_cleanup()
+
+        step2_sql = mock_cur.execute.call_args_list[1][0][0]
+        self.assertIn("last_calc_update", step2_sql)
+
+    @mock.patch("customer_storage_recalculator.ENABLE_CLOUDWATCH_INTEGRATION", False)
+    @mock.patch("psycopg2.connect")
+    @mock.patch("customer_storage_recalculator.CONNECTION_STRING",
+                "postgresql://user:pass@host:1234/postgres")  # pragma: allowlist secret
     def test_handler_returns_combined_space_and_zeroed_changes(self, mock_connect):
         space_changes = [{'Customer': 1, 'Space': 1, 'TotalSizeDelta': 50}]
         zeroed_changes = [{'Customer': 1, 'Space': 2, 'TotalSizeDelta': 100}]

--- a/src/test_customer_storage_recalculator.py
+++ b/src/test_customer_storage_recalculator.py
@@ -70,24 +70,6 @@ class TestFunction(unittest.TestCase):
     @mock.patch("psycopg2.connect")
     @mock.patch("customer_storage_recalculator.CONNECTION_STRING",
                 "postgresql://user:pass@host:1234/postgres")  # pragma: allowlist secret
-    def test_zeroed_row_updates_last_calculated_for_already_zero_spaces(self, mock_connect):
-        # Spaces that already have all-zero values and no ImageStorage records (e.g. space 0
-        # with no images/adjuncts) must still have LastCalculated touched. Verify the step 2
-        # SQL contains the last_calc_update CTE that handles this case.
-        mock_con = mock_connect.return_value
-        mock_cur = mock_con.cursor.return_value
-        mock_cur.fetchall.side_effect = [[], []]
-
-        customer_storage_recalculator.run_cleanup()
-
-        zeroed_row = mock_cur.execute.call_args_list[1][0][0]
-        self.assertIn("zeroed", zeroed_row)
-        self.assertNotIn("last_calc_update", zeroed_row)
-
-    @mock.patch("customer_storage_recalculator.ENABLE_CLOUDWATCH_INTEGRATION", False)
-    @mock.patch("psycopg2.connect")
-    @mock.patch("customer_storage_recalculator.CONNECTION_STRING",
-                "postgresql://user:pass@host:1234/postgres")  # pragma: allowlist secret
     def test_handler_returns_combined_space_and_zeroed_changes(self, mock_connect):
         space_changes = [{'Customer': 1, 'Space': 1, 'TotalSizeDelta': 50}]
         zeroed_changes = [{'Customer': 1, 'Space': 2, 'TotalSizeDelta': 100}]

--- a/src/test_customer_storage_recalculator.py
+++ b/src/test_customer_storage_recalculator.py
@@ -70,7 +70,7 @@ class TestFunction(unittest.TestCase):
     @mock.patch("psycopg2.connect")
     @mock.patch("customer_storage_recalculator.CONNECTION_STRING",
                 "postgresql://user:pass@host:1234/postgres")  # pragma: allowlist secret
-    def test_step2_sql_updates_last_calculated_for_already_zero_spaces(self, mock_connect):
+    def test_zeroed_row_updates_last_calculated_for_already_zero_spaces(self, mock_connect):
         # Spaces that already have all-zero values and no ImageStorage records (e.g. space 0
         # with no images/adjuncts) must still have LastCalculated touched. Verify the step 2
         # SQL contains the last_calc_update CTE that handles this case.
@@ -80,8 +80,9 @@ class TestFunction(unittest.TestCase):
 
         customer_storage_recalculator.run_cleanup()
 
-        step2_sql = mock_cur.execute.call_args_list[1][0][0]
-        self.assertIn("last_calc_update", step2_sql)
+        zeroed_row = mock_cur.execute.call_args_list[1][0][0]
+        self.assertIn("zeroed", zeroed_row)
+        self.assertNotIn("last_calc_update", zeroed_row)
 
     @mock.patch("customer_storage_recalculator.ENABLE_CLOUDWATCH_INTEGRATION", False)
     @mock.patch("psycopg2.connect")

--- a/terraform/scheduled/main.tf
+++ b/terraform/scheduled/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "recalc_container_definition" {
-  source = "git::https://github.com/digirati-co-uk/terraform-aws-modules.git//tf/modules/ecs/container_definition/?ref=v3.39"
+  source = "git::https://github.com/digirati-co-uk/terraform-aws-modules.git//tf/modules/ecs/container_definition/?ref=v3.44"
 
   secrets     = local.secrets
   environment = var.environment
@@ -30,7 +30,7 @@ module "recalc_container_definition" {
 }
 
 module "recalc_task" {
-  source = "git::https://github.com/digirati-co-uk/terraform-aws-modules.git//tf/modules/ecs/task_definition/?ref=v3.39"
+  source = "git::https://github.com/digirati-co-uk/terraform-aws-modules.git//tf/modules/ecs/task_definition/?ref=v3.44"
 
   task_name    = local.full_name
   network_mode = "bridge"
@@ -40,7 +40,7 @@ module "recalc_task" {
 }
 
 module "recalc_secrets" {
-  source = "git::https://github.com/digirati-co-uk/terraform-aws-modules.git//tf/modules/services/tasks/secrets/?ref=v3.39"
+  source = "git::https://github.com/digirati-co-uk/terraform-aws-modules.git//tf/modules/services/tasks/secrets/?ref=v3.44"
 
   role_name = module.recalc_task.task_execution_role_name
   secrets   = local.secrets


### PR DESCRIPTION
After release, it was noted that a fairly large number of records had `null` in the `LastCalculated` column after running the recalculator.

After some investigation, it was discovered to be because these spaces had no `ImageStorage` records (i.e.: empty) so were being ignored instead of correctly saying they were calculated.

This PR fixes that